### PR TITLE
.github/workflows/main.yml: install opencv just once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           pip3 install -e .[dev] --no-deps
-          pip3 install opencv-python
           #pip3 check
 
       - name: Test


### PR DESCRIPTION
We now install OpenCV via setup.py, so there's no need to explicitly
install it again.