### PR TITLE
rotomap-edit: display titles again

### DIFF
--- a/mel/lib/image.py
+++ b/mel/lib/image.py
@@ -168,6 +168,25 @@ def montage_vertical(border_size, *image_list):
     )
 
 
+def measure_text_height_width(
+    text, font_face=None, font_scale=None, thickness=None
+):
+    if font_face is None:
+        font_face = cv2.FONT_HERSHEY_DUPLEX
+    if font_scale is None:
+        font_scale = 1
+    if thickness is None:
+        thickness = 1
+
+    (width, height), baseline = cv2.getTextSize(
+        text, font_face, font_scale, thickness
+    )
+
+    baseline += thickness
+
+    return height + baseline, width
+
+
 def render_text_as_image(
     text, font_face=None, font_scale=None, thickness=None, color=None
 ):

--- a/mel/rotomap/display.py
+++ b/mel/rotomap/display.py
@@ -71,8 +71,15 @@ class Display:
         self._image_display = screen
 
         self._rect = numpy.array((screen.width, screen.height))
+        title_height, _ = mel.lib.image.measure_text_height_width("abc")
+        self._spacer_height = 10
+        self._image_rect = self._rect - numpy.array(
+            (0, title_height + self._spacer_height)
+        )
 
         self._transform = None
+
+        self._title = ""
 
         self._zoom_pos = None
         self._is_zoomed = False
@@ -82,15 +89,17 @@ class Display:
 
         if self._is_zoomed:
             self._transform = ZoomedImageTransform(
-                image, self._zoom_pos, self._rect, scale=self._zoom_level
+                image, self._zoom_pos, self._image_rect, scale=self._zoom_level
             )
         else:
-            self._transform = FittedImageTransform(image, self._rect)
+            self._transform = FittedImageTransform(image, self._image_rect)
 
         image = self._transform.render()
         if overlay is not None:
             image = overlay(image, self._transform)
 
+        caption = mel.lib.image.render_text_as_image(self._title)
+        image = mel.lib.image.montage_vertical(10, image, caption)
         self._image_display.show_opencv_image(image)
 
     def set_fitted(self):
@@ -116,9 +125,8 @@ class Display:
     def windowxy_to_imagexy(self, window_x, window_y):
         return self._transform.transformedxy_to_imagexy(window_x, window_y)
 
-    def set_title(self, _):
-        # cv2.setWindowTitle(self._name, title)
-        pass
+    def set_title(self, title):
+        self._title = title
 
 
 def make_composite_overlay(*overlays):


### PR DESCRIPTION
Make it easier to know what image or rotomap you're operating on, by
rendering the give 'title' of the image again. This used to be displayed
in the title of the window, but now we're properly full-screen we need
to render it in the image.