### PR TITLE
rotomap edit: 'c' to confirm all moles

### DIFF
--- a/mel/cmd/rotomapedit.py
+++ b/mel/cmd/rotomapedit.py
@@ -30,6 +30,7 @@ In 'mole edit' mode:
     Press 'o' to toggle follow mode.
     Press 'm' to toggle move mode.
     Press 'i' to 'rotomap identify' in the current image.
+    Press 'c' to to confirm all moles in the current image.
     Press enter to toggle mole markers.
 
 In 'mask edit' mode:
@@ -288,6 +289,8 @@ class MoleEditController:
             mel.rotomap.moles.save_image_moles(new_moles, str(frame.path))
             editor.moledata.reload()
             editor.show_current()
+        elif key == pygame.K_c:
+            editor.confirm_all()
 
         if self.sub_controller:
             try:

--- a/mel/rotomap/display.py
+++ b/mel/rotomap/display.py
@@ -637,6 +637,12 @@ class Editor:
         self.moledata.save_moles()
         self.show_current()
 
+    def confirm_all(self):
+        for m in self.moledata.moles:
+            m["is_uuid_canonical"] = True
+        self.moledata.save_moles()
+        self.show_current()
+
     def set_mole_uuid(self, mouse_x, mouse_y, mole_uuid, is_canonical=True):
         image_x, image_y = self.display.windowxy_to_imagexy(mouse_x, mouse_y)
         mel.rotomap.moles.set_nearest_mole_uuid(


### PR DESCRIPTION
Increasingly, rotmap-identify will get everything right. In these cases,
we can save quite a few clicks by accepting all the identifications with
a single key-press. This is also very satisfying :)