### PR TITLE
mel rotomap: use new TimeLogger to build a picture of what takes time

### DIFF
--- a/mel/cmd/rotomapedit.py
+++ b/mel/cmd/rotomapedit.py
@@ -462,7 +462,6 @@ class Controller:
         self._visit_list = VisitList(visit_list)
 
         self._logger = logger
-        logger.reset(path=editor.moledata.image_path, mode="editmole")
         self._melroot = mel.lib.fs.find_melroot()
         self.moleedit_controller = MoleEditController(
             editor, follow, copy_to_clipboard
@@ -472,9 +471,12 @@ class Controller:
         self.boundingarea_controller = BoundingAreaController()
         self.automoledebug_controller = AutomoleDebugController()
         self.current_controller = self.moleedit_controller
+        logger.reset(mode="editmole")
 
         self.zooms = [1.0, 0.75, 0.5, 0.25, 2.0, 1.75, 1.5]
         self.zoom_index = 0
+
+        self._reset_logger_new_image(editor)
 
     def on_mouse_event(self, editor, event):
         # Import pygame as late as possible, to avoid displaying its

--- a/mel/cmd/rotomapedit.py
+++ b/mel/cmd/rotomapedit.py
@@ -579,7 +579,7 @@ def process_args(args):
     if args.visit_list_file:
         visit_list = args.visit_list_file.read().splitlines()
 
-    with mel.lib.common.timelogger_context() as logger:
+    with mel.lib.common.timelogger_context("rotomap-edit") as logger:
         with mel.lib.fullscreenui.fullscreen_context() as screen:
             editor = mel.rotomap.display.Editor(args.ROTOMAP, screen)
 

--- a/mel/cmd/rotomapedit.py
+++ b/mel/cmd/rotomapedit.py
@@ -579,9 +579,7 @@ def process_args(args):
     if args.visit_list_file:
         visit_list = args.visit_list_file.read().splitlines()
 
-    timelog_path = mel.lib.fs.find_melroot() / "timelog.csv"
-
-    with mel.lib.common.timelogger_context(timelog_path) as logger:
+    with mel.lib.common.timelogger_context() as logger:
         with mel.lib.fullscreenui.fullscreen_context() as screen:
             editor = mel.rotomap.display.Editor(args.ROTOMAP, screen)
 

--- a/mel/lib/common.py
+++ b/mel/lib/common.py
@@ -321,9 +321,9 @@ def process_context_detail_args(args):
 
 
 class TimeLogger:
-    def __init__(self, csv_writer):
+    def __init__(self, csv_writer, command):
         self._writer = csv_writer
-        self._command = "rotomap-edit"
+        self._command = command
         self._mode = ""
         self._path = ""
         self._start = self._now()
@@ -350,13 +350,13 @@ class TimeLogger:
 
 
 @contextlib.contextmanager
-def timelogger_context():
+def timelogger_context(command):
     path = mel.lib.fs.find_melroot() / "timelog.csv"
     if not path.exists():
         path.write_text("command,mode,path,start,elapsed_secs\n")
     with path.open("a") as f:
         csv_writer = csv.writer(f, dialect="unix", quoting=csv.QUOTE_MINIMAL)
-        logger = TimeLogger(csv_writer)
+        logger = TimeLogger(csv_writer, command)
         with contextlib.closing(logger):
             yield logger
 

--- a/mel/lib/common.py
+++ b/mel/lib/common.py
@@ -350,7 +350,8 @@ class TimeLogger:
 
 
 @contextlib.contextmanager
-def timelogger_context(path):
+def timelogger_context():
+    path = mel.lib.fs.find_melroot() / "timelog.csv"
     if not path.exists():
         path.write_text("command,mode,path,start,elapsed_secs\n")
     with path.open("a") as f:

--- a/mel/lib/fullscreenui.py
+++ b/mel/lib/fullscreenui.py
@@ -153,6 +153,7 @@ class LeftRightDisplay:
             )
 
         self.display = screen
+        self.image_path = None
         self._image_list = image_list
         self._index = 0
         self.show()
@@ -176,6 +177,7 @@ class LeftRightDisplay:
     def show(self):
         if self._image_list:
             path = self._image_list[self._index]
+            self.image_path = path
             caption = mel.lib.image.render_text_as_image(str(path))
             image = mel.lib.image.letterbox(
                 self._get_image(path), self.display.width, self.display.height
@@ -183,6 +185,7 @@ class LeftRightDisplay:
             image = mel.lib.image.montage_vertical(10, image, caption)
             self.display.show_opencv_image(image)
         else:
+            self.image_path = None
             self.display.show_opencv_image(
                 mel.lib.common.new_image(
                     self.display.height, self.display.width


### PR DESCRIPTION
The `mel rotomap` workflow is still quite time-consuming.

As a first step towards optimisation, get a broad picture of where time is being spent. Create a `.csv` log of which UI commands are run, and roughly how much time is spent in a particular mode on a particular subject.