### PR TITLE
 rotomap compare-extra-stem: check performance,  test_smoke: --extra-stem variants, compare and merge

### DIFF
--- a/mel/cmd/mel.py
+++ b/mel/cmd/mel.py
@@ -15,6 +15,7 @@ import mel.cmd.rotomapautomark
 import mel.cmd.rotomapautomask
 import mel.cmd.rotomapcalcspace
 import mel.cmd.rotomapcompare
+import mel.cmd.rotomapcompareextrastem
 import mel.cmd.rotomapconfirm
 import mel.cmd.rotomapedit
 import mel.cmd.rotomapfiltermarks
@@ -49,6 +50,7 @@ COMMANDS = {
         "automask": mel.cmd.rotomapautomask,
         "calc-space": mel.cmd.rotomapcalcspace,
         "compare": mel.cmd.rotomapcompare,
+        "compare-extra-stem": mel.cmd.rotomapcompareextrastem,
         "confirm": mel.cmd.rotomapconfirm,
         "edit": mel.cmd.rotomapedit,
         "filter-marks": mel.cmd.rotomapfiltermarks,

--- a/mel/cmd/rotomapcompareextrastem.py
+++ b/mel/cmd/rotomapcompareextrastem.py
@@ -1,0 +1,77 @@
+"""Merge data to data in an 'extra stem' namespace."""
+
+import mel.rotomap.automark
+import mel.rotomap.moles
+
+
+def setup_parser(parser):
+    parser.add_argument(
+        "EXTRA_STEM", help="The 'extra stem' namespace to merge to."
+    )
+    parser.add_argument(
+        "IMAGES", nargs="+", help="A list of paths to images to automark."
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print information about the processing.",
+    )
+    parser.add_argument(
+        "--error-distance",
+        default=0,
+        type=int,
+        help="Radius to merge moles within.",
+    )
+
+
+def process_args(args):
+    total_matched = 0
+    total_missing = 0
+    total_added = 0
+    for path in args.IMAGES:
+        from_moles = mel.rotomap.moles.load_image_moles(path)
+        to_moles = mel.rotomap.moles.load_image_moles(
+            path, extra_stem=args.EXTRA_STEM
+        )
+        (
+            match_uuids,
+            _missing_uuids,
+            added_uuids,
+        ) = mel.rotomap.automark.match_moles_by_pos(
+            from_moles, to_moles, args.error_distance
+        )
+        if args.verbose:
+            print(
+                path,
+                ":",
+                len(match_uuids),
+                len(_missing_uuids),
+                len(added_uuids),
+            )
+        total_matched += len(match_uuids)
+        total_missing += len(_missing_uuids)
+        total_added += len(added_uuids)
+    print("matched:", total_matched)
+    print("missing:", total_missing)
+    print("added:", total_added)
+    # total = total_matched + total_missing + total_added
+    print(f"Recall: {total_matched / (total_matched + total_missing):.0%}")
+    print(f"Precision: {total_matched / (total_matched + total_added):.0%}")
+
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2022 Angelos Evripiotis.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------ END-OF-FILE ----------------------------------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -103,6 +103,9 @@ def test_smoke():
             *target_image_files
         )
         expect_ok(
+            "mel", "rotomap", "compare-extra-stem", "smoke", *target_image_files
+        )
+        expect_ok(
             "mel", "rotomap", "merge-extra-stem", "smoke", *target_image_files
         )
         expect_ok("mel", "rotomap", "identify-train", "--extra-stem", "smoke")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -86,6 +86,27 @@ def test_smoke():
         for json_file in target_json_files:
             json_file.with_suffix(".json.bak").rename(json_file)
 
+        expect_ok(
+            "mel",
+            "rotomap",
+            "automark",
+            "--extra-stem",
+            "smoke",
+            *target_image_files
+        )
+        expect_ok(
+            "mel",
+            "rotomap",
+            "filter-marks",
+            "--extra-stem",
+            "smoke",
+            *target_image_files
+        )
+        expect_ok(
+            "mel", "rotomap", "merge-extra-stem", "smoke", *target_image_files
+        )
+        expect_ok("mel", "rotomap", "identify-train", "--extra-stem", "smoke")
+
         expect_ok("mel", "rotomap", "confirm", *target_json_files)
         expect_ok("mel", "rotomap", "mark-unchanged", target_rotomap_2)
         expect_ok("mel", "rotomap", "list", *target_json_files)


### PR DESCRIPTION
Make it possible to compare the data in an 'extra-stem' namespace with
the canonical data in the main namespace.

This includes printing the precision and recall vs. the 'ground truth'
in the main namespace, as well as the raw stats.

For example it can be run like this:

    $ find rotomaps/parts/{Left,Right}*/{Upper,Lower}/2021_* -iname '*.jpg' | xargs mel r compare-extra-stem --error-distance 10 auto
    matched: 2037
    missing: 841
    added: 437
    Recall: 71%
    Precision: 82%

Also, exercise the 'extra stem' paths in the smoke tests.