### PR TITLE
.github/workflows/main.yml: drop 'pull-request'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,7 @@
-# This is a basic workflow to help you get started with Actions
-
 name: tests
 
 # 'workflow_dispatch' is manually from the Actions tab
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
To only build changes on pull-requests once, drop the 'pull-request'
bit. Also drop the boiler-plate comment at the top of the file.