### PR TITLE
rotomap compare-extra-stem --compare-uuids

### DIFF
--- a/mel/cmd/rotomapcompareextrastem.py
+++ b/mel/cmd/rotomapcompareextrastem.py
@@ -23,6 +23,11 @@ def setup_parser(parser):
         type=int,
         help="Radius to merge moles within.",
     )
+    parser.add_argument(
+        "--compare-uuids",
+        action="store_true",
+        help="Also compare UUIDs for matching.",
+    )
 
 
 def process_args(args):
@@ -49,9 +54,19 @@ def process_args(args):
                 len(_missing_uuids),
                 len(added_uuids),
             )
-        total_matched += len(match_uuids)
-        total_missing += len(_missing_uuids)
-        total_added += len(added_uuids)
+        if args.compare_uuids:
+            total_missing += len(_missing_uuids)
+            total_added += len(added_uuids)
+            for from_uuid, to_uuid in match_uuids:
+                if from_uuid == to_uuid:
+                    total_matched += 1
+                else:
+                    total_missing += 1
+                    total_added += 1
+        else:
+            total_matched += len(match_uuids)
+            total_missing += len(_missing_uuids)
+            total_added += len(added_uuids)
     print("matched:", total_matched)
     print("missing:", total_missing)
     print("added:", total_added)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -110,7 +110,11 @@ def test_smoke():
             *target_image_files
         )
         expect_ok(
-            "mel", "rotomap", "merge-extra-stem", "smoke", *target_image_files
+            "mel",
+            "rotomap",
+            "compare-extra-stem",
+            "smoke",
+            *target_image_files
         )
         expect_ok(
             "mel",
@@ -119,6 +123,17 @@ def test_smoke():
             "--extra-stem",
             "smoke",
             *target_image_files
+        )
+        expect_ok(
+            "mel",
+            "rotomap",
+            "compare-extra-stem",
+            "--compare-uuids",
+            "smoke",
+            *target_image_files
+        )
+        expect_ok(
+            "mel", "rotomap", "merge-extra-stem", "smoke", *target_image_files
         )
         expect_ok("mel", "rotomap", "identify-train", "--extra-stem", "smoke")
 


### PR DESCRIPTION
Add a `--compare-uuids` argument to `mel rotomap compare-extra-stem`,
for end-to-end performance comparison vs. the 'ground truth'.

This means that you can see how the automatic marking and identification
performs from just an image through to matching the moles in the image
with the marked-up versions.

For example, you can run it like this:

    $ find rotomaps/parts/{Left,Right}*/{Upper,Lower}/2021_* -iname '*.jpg' | xargs mel r compare-extra-stem --error-distance 10 auto --compare-uuids
    matched: 1861
    missing: 1017
    added: 613
    Recall: 65%
    Precision: 75%

Note that the numbers above are from testing on things it was trained
on, so it's not entirely indicative of expected performance on a new
dataset.