### PR TITLE
fixup! rotomap compare: auto-align when changing images

### DIFF
--- a/mel/cmd/rotomapcompare.py
+++ b/mel/cmd/rotomapcompare.py
@@ -351,6 +351,7 @@ class ImageCompareDisplay:
         )
         common_uuids.remove(target_uuid)
         if not common_uuids:
+            self._show()
             return
 
         left_target_pos = [


### PR DESCRIPTION
Make sure we actually _show() from all returns of the align and show
function.