### PR TITLE
TimeLogger: log fractional seconds

### DIFF
--- a/mel/lib/common.py
+++ b/mel/lib/common.py
@@ -331,7 +331,7 @@ class TimeLogger:
 
     def reset(self, *, command=None, mode=None, path=None):
         now = self._now()
-        elapsed = int((now - self._start).total_seconds())
+        elapsed = (now - self._start).total_seconds()
         self._writer.writerow(
             [self._command, self._mode, self._path, self._start, elapsed]
         )


### PR DESCRIPTION
It turns out that there is a lot of time spent rapidly flipping between modes, which ends up with duractions being truncated to zero. Preserve these and don't convert to int before writing out.