### PR TITLE
test_automark: first test, type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ mel.egg-info/
 build/
 Pipfile
 Pipfile.lock
+notebooks/

--- a/mel/rotomap/automark.py
+++ b/mel/rotomap/automark.py
@@ -1,6 +1,7 @@
 """Automatically mark moles on rotomap images."""
 
 import copy
+from typing import Dict, List, Union
 
 import numpy
 
@@ -8,8 +9,37 @@ import mel.lib.image
 import mel.rotomap.detectmoles
 import mel.rotomap.moles
 
+# Each mole should have these fields:
+#   uuid: str
+#   x: int
+#   y: int
+#   radius: int
+Moles = List[Dict[str, Union[str, int]]]
 
-def merge_in_radiuses(targets, radii_sources, error_distance, only_merge):
+
+def merge_in_radiuses(
+    targets: Moles,
+    radii_sources: Moles,
+    error_distance: int,
+    only_merge: bool,
+) -> list:
+    """Merge radius values from radius source dictionaries into target
+    dictionaries based on their positions.
+
+    Args:
+        targets (list): A list of dictionaries representing the target objects.
+            Each dictionary must have a unique "uuid" key and may contain "x" and "y" keys representing the position of the target.
+        radii_sources (list): A list of dictionaries representing the radius source objects.
+            Each dictionary must have a unique "uuid" key and may contain "x" and "y" keys representing the position of the radius source,
+            as well as a "radius" key representing the radius value.
+        error_distance (int): The maximum allowed distance for matching target and radius source objects.
+        only_merge (bool): Indicates whether to only merge the radius values into the target dictionaries or also include unmatched radius source dictionaries in the results.
+
+    Returns:
+        list: A list of dictionaries representing the merged target and radius source objects.
+            The dictionaries in the list are deep copies of the target dictionaries with the merged radius values.
+            If only_merge is False, any unmatched radius source dictionaries are also included in the list.
+    """
     match_uuids, _, added_uuids = match_moles_by_pos(
         targets, radii_sources, error_distance
     )

--- a/tests/rotomap/test_automark.py
+++ b/tests/rotomap/test_automark.py
@@ -1,0 +1,32 @@
+"""Test suite for mel.rotomap.relate."""
+
+import mel.rotomap.automark as automark
+
+
+# returns a list of targets with updated radii if there are matching radii sources within error_distance
+def test_targets_with_updated_radii():
+    # Arrange
+    targets = [
+        {"uuid": "1", "x": 0, "y": 0},
+        {"uuid": "2", "x": 1, "y": 1},
+        {"uuid": "3", "x": 2, "y": 2}
+    ]
+    radii_sources = [
+        {"uuid": "4", "radius": 7, "x": 0, "y": 0},
+        {"uuid": "5", "radius": 12, "x": 1, "y": 1},
+        {"uuid": "6", "radius": 18, "x": 2, "y": 2},
+    ]
+    error_distance = 3
+    only_merge = False
+
+    # Act
+    result = automark.merge_in_radiuses(targets, radii_sources, error_distance, only_merge)
+
+    # Assert
+    assert len(result) == 3
+    assert result[0]["uuid"] == "1"
+    assert result[0]["radius"] == 7
+    assert result[1]["uuid"] == "2"
+    assert result[1]["radius"] == 12
+    assert result[2]["uuid"] == "3"
+    assert result[2]["radius"] == 18


### PR DESCRIPTION
This PR introduces type hints to the `merge_in_radiuses` function in `mel/rotomap/automark.py` and adds a new test case for this function in `tests/rotomap/test_automark.py`. The type hints improve code readability and maintainability, while the new test case ensures the function's correctness.

Also add `notebooks` to `.gitignore`, for local experimentation.