### PR TITLE
Add tests for automark.merge_in_radiuses function

### DIFF
--- a/mel/rotomap/automark.py
+++ b/mel/rotomap/automark.py
@@ -14,6 +14,10 @@ import mel.rotomap.moles
 #   x: int
 #   y: int
 #   radius: int
+#
+# Note that in Python 3.11 we can use TypedDict to enforce this,
+# and make radius NotRequired.
+#
 Moles = List[Dict[str, Union[str, int]]]
 
 

--- a/tests/rotomap/test_automark.py
+++ b/tests/rotomap/test_automark.py
@@ -55,3 +55,31 @@ def test_merge_in_radiuses_happy_only_merge():
     assert result[1]["radius"] == 12
     assert result[2]["uuid"] == "3"
     assert result[2]["radius"] == 18
+
+
+def test_merge_in_radiuses_happy_not_only_merge():
+    targets = [
+        {"uuid": "1", "x": 0, "y": 0},
+        {"uuid": "2", "x": 1, "y": 1},
+        {"uuid": "3", "x": 2, "y": 2}
+    ]
+    radii_sources = [
+        {"uuid": "4", "radius": 7, "x": 0, "y": 0},
+        {"uuid": "5", "radius": 12, "x": 1, "y": 1},
+        {"uuid": "6", "radius": 18, "x": 2, "y": 2},
+        {"uuid": "7", "radius": 24, "x": 3, "y": 3},
+    ]
+    error_distance = 3
+    only_merge = False
+
+    result = automark.merge_in_radiuses(targets, radii_sources, error_distance, only_merge)
+
+    assert len(result) == 4
+    assert result[0]["uuid"] == "1"
+    assert result[0]["radius"] == 7
+    assert result[1]["uuid"] == "2"
+    assert result[1]["radius"] == 12
+    assert result[2]["uuid"] == "3"
+    assert result[2]["radius"] == 18
+    assert result[3]["uuid"] == "7"
+    assert result[3]["radius"] == 24

--- a/tests/rotomap/test_automark.py
+++ b/tests/rotomap/test_automark.py
@@ -3,8 +3,7 @@
 import mel.rotomap.automark as automark
 
 
-# returns a list of targets with updated radii if there are matching radii sources within error_distance
-def test_targets_with_updated_radii():
+def test_merge_in_radiuses_happy():
     # Arrange
     targets = [
         {"uuid": "1", "x": 0, "y": 0},
@@ -23,6 +22,32 @@ def test_targets_with_updated_radii():
     result = automark.merge_in_radiuses(targets, radii_sources, error_distance, only_merge)
 
     # Assert
+    assert len(result) == 3
+    assert result[0]["uuid"] == "1"
+    assert result[0]["radius"] == 7
+    assert result[1]["uuid"] == "2"
+    assert result[1]["radius"] == 12
+    assert result[2]["uuid"] == "3"
+    assert result[2]["radius"] == 18
+
+
+def test_merge_in_radiuses_happy_only_merge():
+    targets = [
+        {"uuid": "1", "x": 0, "y": 0},
+        {"uuid": "2", "x": 1, "y": 1},
+        {"uuid": "3", "x": 2, "y": 2}
+    ]
+    radii_sources = [
+        {"uuid": "4", "radius": 7, "x": 0, "y": 0},
+        {"uuid": "5", "radius": 12, "x": 1, "y": 1},
+        {"uuid": "6", "radius": 18, "x": 2, "y": 2},
+        {"uuid": "7", "radius": 24, "x": 3, "y": 3},  # This one is ignored.
+    ]
+    error_distance = 3
+    only_merge = True
+
+    result = automark.merge_in_radiuses(targets, radii_sources, error_distance, only_merge)
+
     assert len(result) == 3
     assert result[0]["uuid"] == "1"
     assert result[0]["radius"] == 7


### PR DESCRIPTION
This pull request adds tests for the `merge_in_radiuses` function in the `automark` module. The tests cover different scenarios and ensure the correct behavior of the function.