### PR TITLE
mel status: also read ignore-missing-carryforward

### DIFF
--- a/mel/cmd/status.py
+++ b/mel/cmd/status.py
@@ -470,6 +470,10 @@ def check_rotomap_list(notices, rotomap_list):
         newest.path, mel.rotomap.moles.IGNORE_MISSING_FILENAME
     )
 
+    ignore_missing |= mel.rotomap.moles.load_potential_set_file(
+        newest.path, mel.rotomap.moles.IGNORE_MISSING_CARRYFORWARD_FILENAME
+    )
+
     diff = mel.rotomap.moles.MoleListDiff(
         old_uuids, new_uuids, ignore_new, ignore_missing
     )

--- a/mel/rotomap/moles.py
+++ b/mel/rotomap/moles.py
@@ -18,6 +18,7 @@ KEY_IS_UNCHANGED = "is_unchanged"
 
 IGNORE_NEW_FILENAME = "ignore-new"
 IGNORE_MISSING_FILENAME = "ignore-missing"
+IGNORE_MISSING_CARRYFORWARD_FILENAME = "ignore-missing-carryforward"
 IGNORE_CHANGED_FILENAME = "ignore-changed"
 ROTOMAP_DIR_LESIONS_FILENAME = "lesions.json"
 


### PR DESCRIPTION
Make it easier to manage a persistent list of moles that have gone away, separate from ones that are merely not visible in the current rotomap.