### PR TITLE
ZoomableMixin: preserve scale across image size

### DIFF
--- a/mel/lib/fullscreenui.py
+++ b/mel/lib/fullscreenui.py
@@ -190,6 +190,7 @@ class ZoomableMixin:
         self._transform = None
         self._zoom_pos = None
         self._zoom_virt_pos = None
+        self._zoom_orig_shape = None
         self._is_zoomed = False
         self._zoom_level = 1
 
@@ -201,8 +202,20 @@ class ZoomableMixin:
                 self._zoom_virt_pos = self._zoom_pos / image.shape[:2]
             else:
                 self._zoom_pos = self._zoom_virt_pos * image.shape[:2]
+            if self._zoom_orig_shape is None:
+                self._zoom_orig_shape = image.shape[:2]
+            zoom_scale = (
+                sum(
+                    [
+                        self._zoom_orig_shape[0] / image.shape[0],
+                        self._zoom_orig_shape[1] / image.shape[1],
+                    ]
+                )
+                / 2
+            )
+            zoom_level = self._zoom_level * zoom_scale
             self._transform = mel.lib.fullscreenui.ZoomedImageTransform(
-                image, self._zoom_pos, window_rect, scale=self._zoom_level
+                image, self._zoom_pos, window_rect, scale=zoom_level
             )
         else:
             self._transform = mel.lib.fullscreenui.FittedImageTransform(
@@ -214,6 +227,7 @@ class ZoomableMixin:
 
     def set_fitted(self):
         self._is_zoomed = False
+        self._zoom_orig_shape = None
 
     def set_zoom_level(self, zoom_level=1):
         self._zoom_level = zoom_level


### PR DESCRIPTION
If the previous image is a different size than the current one, assume
that it is representing the same scene but with a different resolution.

Therefore, try to preserve the apparent size of things on screen by
adjusting the zoom level accordingly.

Reset this scaling whenever switching back the fitted view. This means
that we always get the 'true' resolution when zooming initially.