### PR TITLE
test: add smoke test for `mel rotomap resize` command

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -129,11 +129,11 @@ def test_smoke():
         expect_ok("mel", "rotomap", "loadsave", *target_json_files)
 
         # Test resize functionality with smaller dimensions
-        if target_image_files:
-            expect_ok(
-                "mel", "rotomap", "resize", "--width", "100", "--height", "100",
-                str(target_image_files[0])
-            )
+        assert target_image_files, "No target image files found for resize test"
+        expect_ok(
+            "mel", "rotomap", "resize", "--width", "100", "--height", "100",
+            str(target_image_files[0])
+        )
 
         expect_ok("mel", "status", "-ttdd")
         expect_ok("mel", "micro", "list")
@@ -160,7 +160,8 @@ def expect_returncode(expected_code, *args):
 
 
 # -----------------------------------------------------------------------------
-# Copyright (C) 2015-2020 Angelos Evripiotis.
+# Copyright (C) 2015-2025 Angelos Evripiotis.
+# Generated with assistance from Claude Code
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -161,7 +161,7 @@ def expect_returncode(expected_code, *args):
 
 # -----------------------------------------------------------------------------
 # Copyright (C) 2015-2025 Angelos Evripiotis.
-# Generated with assistance from Claude Code
+# Generated with assistance from Claude Code.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -127,6 +127,14 @@ def test_smoke():
         expect_ok("mel", "rotomap", "mark-unchanged", target_rotomap_2)
         expect_ok("mel", "rotomap", "list", *target_json_files)
         expect_ok("mel", "rotomap", "loadsave", *target_json_files)
+
+        # Test resize functionality with smaller dimensions
+        if target_image_files:
+            expect_ok(
+                "mel", "rotomap", "resize", "--width", "100", "--height", "100",
+                str(target_image_files[0])
+            )
+
         expect_ok("mel", "status", "-ttdd")
         expect_ok("mel", "micro", "list")
 


### PR DESCRIPTION
Adds a basic smoke test for the resize functionality by resizing one of the test images to 100x100 pixels. This ensures the resize command doesn't error out during the test suite.

Fixes #429

Generated with [Claude Code](https://claude.ai/code)