### PR TITLE
Improve test running performance with ruff and pytest timing

### DIFF
--- a/meta/autofix.sh
+++ b/meta/autofix.sh
@@ -11,6 +11,11 @@ printf "."
 black --quiet --line-length 79 $allscripts
 printf "."
 
+# Use ruff to fix import sorting and other auto-fixable issues
+python3 -m ruff check --fix mel/
+printf "."
+
+# Keep isort as fallback for any remaining import issues
 isort --quiet --apply $allscripts
 printf "."
 

--- a/meta/autofix.sh
+++ b/meta/autofix.sh
@@ -5,14 +5,17 @@ cd "$(dirname "$0")"/..
 
 allscripts=$(find mel/ -iname '*.py' |  tr '\n' ' ')
 
-docformatter -i $allscripts
+uv run docformatter -i $allscripts
 printf "."
 
-# Use ruff for formatting and import sorting (replaces black and isort)
-python3 -m ruff format --line-length 79 mel/
+uv run ruff format --line-length 79 $allscripts
 printf "."
 
-python3 -m ruff check --fix mel/
+uv run ruff check --fix $allscripts
 printf "."
 
 echo
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2025 Angelos Evripiotis.
+# Generated with assistance from Claude Code.

--- a/meta/autofix.sh
+++ b/meta/autofix.sh
@@ -8,15 +8,11 @@ allscripts=$(find mel/ -iname '*.py' |  tr '\n' ' ')
 docformatter -i $allscripts
 printf "."
 
-black --quiet --line-length 79 $allscripts
+# Use ruff for formatting and import sorting (replaces black and isort)
+python3 -m ruff format --line-length 79 mel/
 printf "."
 
-# Use ruff to fix import sorting and other auto-fixable issues
 python3 -m ruff check --fix mel/
-printf "."
-
-# Keep isort as fallback for any remaining import issues
-isort --quiet --apply $allscripts
 printf "."
 
 echo

--- a/meta/static_tests.sh
+++ b/meta/static_tests.sh
@@ -6,13 +6,11 @@ set -e # exit immediately on error
 # cd to the root of the repository, so all the paths are relative to that
 cd "$(dirname "$0")"/..
 
-allscripts=$(find mel/ -iname '*.py' |  tr '\n' ' ')
-
 printf '.'
 python3 -m pylint --errors-only mel/
 
 printf '.'
-python3 -m pyflakes $allscripts
+python3 -m ruff check mel/
 
 printf '.'
 python3 -m vulture \

--- a/meta/static_tests.sh
+++ b/meta/static_tests.sh
@@ -6,17 +6,23 @@ set -e # exit immediately on error
 # cd to the root of the repository, so all the paths are relative to that
 cd "$(dirname "$0")"/..
 
-printf '.'
-python3 -m pylint --errors-only mel/
+allscripts=$(find mel/ -iname '*.py' |  tr '\n' ' ')
 
 printf '.'
-python3 -m ruff check mel/
+uv run python -m pylint --errors-only mel/
 
 printf '.'
-python3 -m vulture \
+uv run ruff check $allscripts
+
+printf '.'
+uv run python -m vulture \
     --ignore-names training_step,validation_step,configure_optimizers \
     --exclude '*__t.py,mel/rotomap/detectmoles.py,mel/rotomap/identifynn.py' \
     mel/
 
 echo OK
 trap - EXIT
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2025 Angelos Evripiotis.
+# Generated with assistance from Claude Code.

--- a/meta/unit_tests.sh
+++ b/meta/unit_tests.sh
@@ -3,4 +3,8 @@
 # cd to the root of the repository, so all the paths are relative to that
 cd "$(dirname "$0")"/..
 
-pytest --doctest-modules --durations=10
+uv run pytest --doctest-modules --durations=10
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2025 Angelos Evripiotis.
+# Generated with assistance from Claude Code.

--- a/meta/unit_tests.sh
+++ b/meta/unit_tests.sh
@@ -3,4 +3,4 @@
 # cd to the root of the repository, so all the paths are relative to that
 cd "$(dirname "$0")"/..
 
-pytest --doctest-modules
+pytest --doctest-modules --durations=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ pyflakes==3.3.2
 pygame==2.6.1
 pylint==3.3.7
 pytest==8.3.5
+ruff==0.8.4
 pytorch-lightning==2.5.0.post0
-ruff==0.8.5
 torchvision==0.22.0
 tqdm==4.67.1
 vulture==2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pygame==2.6.1
 pylint==3.3.7
 pytest==8.3.5
 pytorch-lightning==2.5.0.post0
+ruff==0.8.5
 torchvision==0.22.0
 tqdm==4.67.1
 vulture==2.14

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setuptools.setup(
             'pyflakes',
             'pylint',
             'pytest',
+            'ruff',
             'vulture',
         ]
     },


### PR DESCRIPTION
Implements performance improvements for test running infrastructure:

- Configure pytest to show slowest 10 test durations
- Integrate ruff for faster linting, replacing pyflakes in static checks
- Add ruff auto-fixing to autofix script while keeping existing tools
- Add ruff to requirements and dev dependencies

Note: GitHub workflow changes for uv and timing measurements need to be applied manually due to permissions.

Addresses #440

Generated with [Claude Code](https://claude.ai/code)