### PR TITLE
feat: enable C4 (flake8-comprehensions) checks and fix 7 comprehension improvements

### DIFF
--- a/mel/cmd/microadd.py
+++ b/mel/cmd/microadd.py
@@ -54,7 +54,7 @@ def setup_parser(parser):
 
 def get_context_image_name(path):
     # Paths should alpha-sort to recent last, pick the first jpg
-    children = reversed(sorted(os.listdir(path)))
+    children = sorted(os.listdir(path), reverse=True)
     for name in children:
         # TODO: support more than just '.jpg'
         if name.lower().endswith(".jpg"):

--- a/mel/cmd/rotomapidentifytrain.py
+++ b/mel/cmd/rotomapidentifytrain.py
@@ -204,14 +204,14 @@ def process_args(args):
     num_parts = len(part_to_index)
     num_classes = len(train_dataset.classes)
 
-    model_args = dict(
-        cnn_width=cnn_width,
-        cnn_depth=cnn_depth,
-        num_parts=num_parts,
-        num_classes=num_classes,
-        num_cnns=num_cnns,
-        channels_in=channels_in,
-    )
+    model_args = {
+        "cnn_width": cnn_width,
+        "cnn_depth": cnn_depth,
+        "num_parts": num_parts,
+        "num_classes": num_classes,
+        "num_cnns": num_cnns,
+        "channels_in": channels_in,
+    }
 
     init_model_args = model_args
     if old_metadata is not None:

--- a/mel/lib/moleimaging.py
+++ b/mel/lib/moleimaging.py
@@ -166,9 +166,9 @@ class MoleAcquirer(object):
                     )
                 )
 
-                should_lock = all([int(x) == 0 for x in self._last_stats_diff])
+                should_lock = all(int(x) == 0 for x in self._last_stats_diff)
 
-                should_unlock = any([abs(int(x)) > 1 for x in self._last_stats_diff])
+                should_unlock = any(abs(int(x)) > 1 for x in self._last_stats_diff)
 
                 if not self._is_locked and should_lock:
                     self._is_locked = True

--- a/mel/micro/fs.py
+++ b/mel/micro/fs.py
@@ -102,7 +102,7 @@ def _extend_context_image_name_tuple_tuple(path, context_image_name_tuple_tuple)
 
 def _list_micro_dir_if_exists(path):
     if not path.exists():
-        return tuple()
+        return ()
 
     image_names = []
     for sub in path.iterdir():

--- a/mel/rotomap/automark.py
+++ b/mel/rotomap/automark.py
@@ -48,7 +48,7 @@ def merge_in_radiuses(
         targets, radii_sources, error_distance
     )
 
-    target_to_radii_src = {from_uuid: to_uuid for from_uuid, to_uuid in match_uuids}
+    target_to_radii_src = dict(match_uuids)
     radii_src_radius = {s["uuid"]: s["radius"] for s in radii_sources}
     target_uuid_radius = {
         t_uuid: radii_src_radius[target_to_radii_src[t_uuid]]

--- a/mel/rotomap/identifynn.py
+++ b/mel/rotomap/identifynn.py
@@ -127,7 +127,7 @@ class RotomapsClassMapping:
                     for m in moles:
                         all_uuids.add(m["uuid"])
 
-        self.classes = sorted(list(all_uuids))
+        self.classes = sorted(all_uuids)
         self.class_to_index = {cls: i for i, cls in enumerate(self.classes)}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ target-version = "py38"
 # - T10: flake8-debugger (detect debugger imports like pdb)
 # - ISC: flake8-implicit-str-concat (implicit string concatenation issues)
 # - RET: flake8-return (return statement improvements)
-extend-select = ["A", "FURB", "N", "PLE", "I", "W", "F", "PIE", "Q", "T10", "ISC", "RET"]
+# - C4: flake8-comprehensions (comprehension improvements)
+extend-select = ["A", "FURB", "N", "PLE", "I", "W", "F", "PIE", "Q", "T10", "ISC", "RET", "C4"]
 
 [tool.vulture]
 ignore_names = ["training_step", "validation_step", "configure_optimizers"]

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -12,7 +12,6 @@
 # [ A] test_a_breathing
 # =============================================================================
 
-
 import unittest
 
 import mel.lib.common

--- a/tests/rotomap/test_automark.py
+++ b/tests/rotomap/test_automark.py
@@ -7,7 +7,7 @@ import mel.rotomap.automark as automark
 TARGETS = [
     {"uuid": "1", "x": 0, "y": 0},
     {"uuid": "2", "x": 1, "y": 1},
-    {"uuid": "3", "x": 2, "y": 2}
+    {"uuid": "3", "x": 2, "y": 2},
 ]
 
 RADII_SOURCES = [
@@ -29,7 +29,9 @@ def test_merge_in_radiuses_happy(only_merge, error_distance):
 
     """
     radii_sources = [x for x in RADII_SOURCES if x["uuid"] != "7"]
-    result = automark.merge_in_radiuses(TARGETS, radii_sources, error_distance, only_merge)
+    result = automark.merge_in_radiuses(
+        TARGETS, radii_sources, error_distance, only_merge
+    )
 
     assert len(result) == 3
     assert result[0]["uuid"] == "1"
@@ -50,7 +52,9 @@ def test_merge_in_radiuses_happy_merge_extra(only_merge, error_distance):
     It is either included or not included in the result, depending on only_merge.
 
     """
-    result = automark.merge_in_radiuses(TARGETS, RADII_SOURCES, error_distance, only_merge)
+    result = automark.merge_in_radiuses(
+        TARGETS, RADII_SOURCES, error_distance, only_merge
+    )
 
     if only_merge:
         assert len(result) == 3

--- a/tests/rotomap/test_relate.py
+++ b/tests/rotomap/test_relate.py
@@ -12,7 +12,6 @@
 # [ A] test_a_breathing
 # =============================================================================
 
-
 import unittest
 
 import numpy
@@ -31,7 +30,6 @@ class Test(unittest.TestCase):
         pass
 
     def test_b_pick_value_from_field(self):
-
         value, error = mel.rotomap.relate.pick_value_from_field(
             numpy.array([0, 0]), [(numpy.array([0, 0]), [1, 2])]
         )

--- a/tests/rotomap/test_tricolour.py
+++ b/tests/rotomap/test_tricolour.py
@@ -1,6 +1,5 @@
 """Test suite for mel.rotomap.tricolour."""
 
-
 import unittest
 
 import mel.rotomap.tricolour
@@ -42,7 +41,7 @@ class Test(unittest.TestCase):
             )
         )
 
-        self.assertEqual(len(mapping), num_colours ** 3)
+        self.assertEqual(len(mapping), num_colours**3)
 
         mapping_set = set(mapping)
         self.assertEqual(len(mapping_set), len(mapping))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -12,7 +12,6 @@ import mel.cmd.mel
 
 
 def test_mel_help():
-
     mel_cmd = "mel"
 
     expect_returncode(2, mel_cmd)
@@ -29,7 +28,6 @@ def test_mel_help():
 
 
 def test_mel_debug_help():
-
     mel_cmd = "mel-debug"
 
     expect_returncode(2, mel_cmd)
@@ -106,14 +104,10 @@ def test_smoke():
             "filter-marks",
             "--extra-stem",
             "smoke",
-            *target_image_files
+            *target_image_files,
         )
-        expect_ok(
-            "mel", "rotomap", "compare-extra-stem", "smoke", *target_image_files
-        )
-        expect_ok(
-            "mel", "rotomap", "compare-extra-stem", "smoke", *target_image_files
-        )
+        expect_ok("mel", "rotomap", "compare-extra-stem", "smoke", *target_image_files)
+        expect_ok("mel", "rotomap", "compare-extra-stem", "smoke", *target_image_files)
         expect_ok(
             "mel", "rotomap", "identify", "--extra-stem", "smoke", *target_image_files
         )
@@ -123,7 +117,7 @@ def test_smoke():
             "compare-extra-stem",
             "--compare-uuids",
             "smoke",
-            *target_image_files
+            *target_image_files,
         )
         expect_ok("mel", "rotomap", "merge-extra-stem", "smoke", *target_image_files)
         expect_ok("mel", "rotomap", "identify-train", "--extra-stem", "smoke")
@@ -136,8 +130,14 @@ def test_smoke():
         # Test resize functionality with smaller dimensions
         assert target_image_files, "No target image files found for resize test"
         expect_ok(
-            "mel", "rotomap", "resize", "--width", "100", "--height", "100",
-            str(target_image_files[0])
+            "mel",
+            "rotomap",
+            "resize",
+            "--width",
+            "100",
+            "--height",
+            "100",
+            str(target_image_files[0]),
         )
 
         expect_ok("mel", "status", "-ttdd")
@@ -155,15 +155,36 @@ def test_smoke():
 
         # Test additional non-interactive rotomap commands
         # uuid command returns 1 when no matches found, so expect that
-        expect_returncode(1, "mel", "rotomap", "uuid", "nonexistent-prefix", *target_json_files)
-        expect_ok(
-            "mel", "rotomap", "rm", "--uuids", "nonexistent-uuid", "--files",
-            *target_json_files
+        expect_returncode(
+            1, "mel", "rotomap", "uuid", "nonexistent-prefix", *target_json_files
         )
-        expect_ok("mel", "rotomap", "guess-missing",
-                  str(target_image_files[0]), str(target_image_files[1]))
-        expect_ok("mel", "rotomap", "guess-refine", "--max-moles", "1", "--dino-size", "small",
-                  str(target_image_files[0]), str(target_image_files[1]))
+        expect_ok(
+            "mel",
+            "rotomap",
+            "rm",
+            "--uuids",
+            "nonexistent-uuid",
+            "--files",
+            *target_json_files,
+        )
+        expect_ok(
+            "mel",
+            "rotomap",
+            "guess-missing",
+            str(target_image_files[0]),
+            str(target_image_files[1]),
+        )
+        expect_ok(
+            "mel",
+            "rotomap",
+            "guess-refine",
+            "--max-moles",
+            "1",
+            "--dino-size",
+            "small",
+            str(target_image_files[0]),
+            str(target_image_files[1]),
+        )
         # For montage-single, we need a UUID, so let's get one from the first JSON file
         # and use the corresponding image file
         json_file = target_json_files[0]
@@ -174,8 +195,12 @@ def test_smoke():
         if moles_data:
             test_uuid = moles_data[0]["uuid"]
             expect_ok(
-                "mel", "rotomap", "montage-single",
-                corresponding_image, test_uuid, "test_montage.jpg"
+                "mel",
+                "rotomap",
+                "montage-single",
+                corresponding_image,
+                test_uuid,
+                "test_montage.jpg",
             )
         else:
             # Skip montage-single test if no moles found
@@ -200,9 +225,7 @@ def test_smoke_interactive():
         env["MEL_DEBUG_ENQUEUE_KEYPRESSES"] = "K_q"
 
         # Test rotomap edit command (quit immediately)
-        expect_ok_with_env(
-            env, "mel", "rotomap", "edit", str(target_rotomap_0)
-        )
+        expect_ok_with_env(env, "mel", "rotomap", "edit", str(target_rotomap_0))
 
         # Test rotomap compare command with multiple rotomaps
         # Skip for now due to division by zero error in existing code
@@ -227,8 +250,12 @@ def test_smoke_interactive():
             micro_images = list(micro_path.glob("*.jpg"))
             if len(micro_images) >= 2:
                 expect_ok_with_env(
-                    env, "mel", "micro", "compare",
-                    str(micro_images[0]), str(micro_images[1])
+                    env,
+                    "mel",
+                    "micro",
+                    "compare",
+                    str(micro_images[0]),
+                    str(micro_images[1]),
                 )
 
 


### PR DESCRIPTION
Enable C4 (flake8-comprehensions) checks in ruff configuration and fix all 7 existing comprehension issues found in the codebase.

## Changes
- Enable C4 checks in ruff configuration for better comprehension usage
- Fix C413: Remove unnecessary reversed() call in microadd.py
- Fix C408: Convert dict() and tuple() calls to literals
- Fix C419: Remove unnecessary list comprehensions in moleimaging.py
- Fix C416: Rewrite dict comprehension using dict() in automark.py
- Fix C414: Remove unnecessary list() call in identifynn.py

Closes #456

Generated with [Claude Code](https://claude.ai/code)