### PR TITLE
feat: enable C4 (flake8-comprehensions) checks and fix 7 comprehension improvements

### DIFF
--- a/mel/cmd/microadd.py
+++ b/mel/cmd/microadd.py
@@ -54,7 +54,7 @@ def setup_parser(parser):
 
 def get_context_image_name(path):
     # Paths should alpha-sort to recent last, pick the first jpg
-    children = reversed(sorted(os.listdir(path)))
+    children = sorted(os.listdir(path), reverse=True)
     for name in children:
         # TODO: support more than just '.jpg'
         if name.lower().endswith(".jpg"):

--- a/mel/cmd/rotomapidentifytrain.py
+++ b/mel/cmd/rotomapidentifytrain.py
@@ -203,14 +203,14 @@ def process_args(args):
     num_parts = len(part_to_index)
     num_classes = len(train_dataset.classes)
 
-    model_args = dict(
-        cnn_width=cnn_width,
-        cnn_depth=cnn_depth,
-        num_parts=num_parts,
-        num_classes=num_classes,
-        num_cnns=num_cnns,
-        channels_in=channels_in,
-    )
+    model_args = {
+        "cnn_width": cnn_width,
+        "cnn_depth": cnn_depth,
+        "num_parts": num_parts,
+        "num_classes": num_classes,
+        "num_cnns": num_cnns,
+        "channels_in": channels_in,
+    }
 
     init_model_args = model_args
     if old_metadata is not None:

--- a/mel/lib/moleimaging.py
+++ b/mel/lib/moleimaging.py
@@ -160,9 +160,9 @@ class MoleAcquirer:
                     )
                 )
 
-                should_lock = all([int(x) == 0 for x in self._last_stats_diff])
+                should_lock = all(int(x) == 0 for x in self._last_stats_diff)
 
-                should_unlock = any([abs(int(x)) > 1 for x in self._last_stats_diff])
+                should_unlock = any(abs(int(x)) > 1 for x in self._last_stats_diff)
 
                 if not self._is_locked and should_lock:
                     self._is_locked = True

--- a/mel/micro/fs.py
+++ b/mel/micro/fs.py
@@ -102,7 +102,7 @@ def _extend_context_image_name_tuple_tuple(path, context_image_name_tuple_tuple)
 
 def _list_micro_dir_if_exists(path):
     if not path.exists():
-        return tuple()
+        return ()
 
     image_names = []
     for sub in path.iterdir():

--- a/mel/rotomap/automark.py
+++ b/mel/rotomap/automark.py
@@ -48,7 +48,7 @@ def merge_in_radiuses(
         targets, radii_sources, error_distance
     )
 
-    target_to_radii_src = {from_uuid: to_uuid for from_uuid, to_uuid in match_uuids}
+    target_to_radii_src = dict(match_uuids)
     radii_src_radius = {s["uuid"]: s["radius"] for s in radii_sources}
     target_uuid_radius = {
         t_uuid: radii_src_radius[target_to_radii_src[t_uuid]]

--- a/mel/rotomap/identifynn.py
+++ b/mel/rotomap/identifynn.py
@@ -127,7 +127,7 @@ class RotomapsClassMapping:
                     for m in moles:
                         all_uuids.add(m["uuid"])
 
-        self.classes = sorted(list(all_uuids))
+        self.classes = sorted(all_uuids)
         self.class_to_index = {cls: i for i, cls in enumerate(self.classes)}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ target-version = "py38"
 [tool.ruff.lint]
 # Rule codes enabled for static analysis:
 # - A: flake8-builtins (prevent shadowing built-ins)
+# - C4: flake8-comprehensions (better list/set/dict comprehensions)
 # - FURB: refurb (modernize Python code)
 # - N: pep8-naming (naming conventions)
 # - PLE: pylint errors (subset of pylint)
@@ -73,7 +74,7 @@ target-version = "py38"
 # - RET: flake8-return (return statement improvements)
 # - SIM: flake8-simplify (code simplification opportunities)
 # - UP: pyupgrade (upgrade Python syntax for newer versions)
-extend-select = ["A", "FURB", "N", "PLE", "I", "W", "F", "PIE", "Q", "T10", "ISC", "RET", "SIM", "UP"]
+extend-select = ["A", "C4", "FURB", "N", "PLE", "I", "W", "F", "PIE", "Q", "T10", "ISC", "RET", "SIM", "UP"]
 
 [tool.vulture]
 ignore_names = ["training_step", "validation_step", "configure_optimizers"]


### PR DESCRIPTION
Enable C4 (flake8-comprehensions) checks in ruff configuration and fix all 7 existing comprehension issues found in the codebase.

## Changes
- Enable C4 checks in ruff configuration for better comprehension usage
- Fix C413: Remove unnecessary reversed() call in microadd.py
- Fix C408: Convert dict() and tuple() calls to literals
- Fix C419: Remove unnecessary list comprehensions in moleimaging.py
- Fix C416: Rewrite dict comprehension using dict() in automark.py
- Fix C414: Remove unnecessary list() call in identifynn.py

Closes #456

Generated with [Claude Code](https://claude.ai/code)