### PR TITLE
feat: introduce Pyright type checker with minimal configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,12 @@
 - Run unit tests: `./meta/unit_tests.sh`
 - Fix formatting: `./meta/autofix.sh`
 
+## Optional Type Checking
+- Run type checking: `pyright` (checks entire codebase)
+- Run type checking on specific files: `pyright path/to/file.py`
+- Run type checking on directory: `pyright path/to/directory/`
+- Note: Install dev dependencies first with `uv pip install -e '.[dev]'`
+
 ## Pre-commit Checklist
 - Fix formatting
 - Fix all tests

--- a/mel/lib/common.py
+++ b/mel/lib/common.py
@@ -133,6 +133,8 @@ def box_moles(image, mole_positions, thickness):
 
 def connect_moles(image, mole_positions):
     for mole_a, mole_b in yield_neighbors(mole_positions):
+        if mole_a is None or mole_b is None:
+            continue
         thickness = max(mole_a[2], mole_b[2])
 
         # draw connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "docformatter",
+    "pyright",
     "pytest",
     "ruff",
     "vulture",
@@ -82,3 +83,10 @@ extend-select = ["A", "B", "C4", "FURB", "N", "PLE", "I", "W", "F", "PIE", "Q", 
 [tool.vulture]
 ignore_names = ["training_step", "validation_step", "configure_optimizers"]
 exclude = ["*__t.py", "mel/rotomap/detectmoles.py", "mel/rotomap/identifynn.py"]
+
+[tool.pyright]
+# Minimal strictness configuration
+pythonVersion = "3.8"
+typeCheckingMode = "basic"
+useLibraryCodeForTypes = true
+reportMissingTypeStubs = "none"


### PR DESCRIPTION
Add Pyright to dev dependencies with basic type checking mode.
Fix None handling issue in mel.lib.common.connect_moles function.
Add optional type checking instructions to CLAUDE.md.

This is a "thin end of the wedge" approach to gradually improve type safety in the codebase.

Closes #474

Generated with [Claude Code](https://claude.ai/code)