### PR TITLE
build: upgrade minimum Python version from 3.8 to 3.12

### DIFF
--- a/mel/cmd/microcompare.py
+++ b/mel/cmd/microcompare.py
@@ -25,7 +25,7 @@ def get_comparison_images(path):
     paths = [os.path.join(micro_path, x) for x in names]
     images = [mel.lib.image.load_image(x) for x in paths]
 
-    for i, (path, img) in enumerate(zip(paths, images)):
+    for i, (path, img) in enumerate(zip(paths, images, strict=False)):
         if img is None:
             raise ValueError(f"Failed to load file: {path}")
         images[i] = mel.lib.image.montage_vertical(

--- a/mel/cmddebug/benchautomark.py
+++ b/mel/cmddebug/benchautomark.py
@@ -69,7 +69,9 @@ def _pair_off_inputs(from_, to):
 
 def _common_path(from_path, to_path):
     common = []
-    for char_from, char_to in zip(reversed(str(from_path)), reversed(str(to_path))):
+    for char_from, char_to in zip(
+        reversed(str(from_path)), reversed(str(to_path)), strict=False
+    ):
         if char_from != char_to:
             break
         common.insert(0, char_from)

--- a/mel/lib/common.py
+++ b/mel/lib/common.py
@@ -320,7 +320,7 @@ class TimeLogger:
         self._start = self._now()
 
     def _now(self):
-        return datetime.datetime.now(datetime.timezone.utc)
+        return datetime.datetime.now(datetime.UTC)
 
     def reset(self, *, command=None, mode=None, path=None):
         now = self._now()

--- a/mel/lib/image.py
+++ b/mel/lib/image.py
@@ -176,7 +176,9 @@ def montage_horizontal(border_size, *image_list):
     size_xy = geometry[0]
     geometry = geometry[1:]
 
-    return arrange_images(size_xy[0], size_xy[1], *list(zip(image_list, geometry)))
+    return arrange_images(
+        size_xy[0], size_xy[1], *list(zip(image_list, geometry, strict=False))
+    )
 
 
 def montage_vertical(border_size, *image_list):
@@ -187,7 +189,9 @@ def montage_vertical(border_size, *image_list):
     size_xy = geometry[0]
     geometry = geometry[1:]
 
-    return arrange_images(size_xy[0], size_xy[1], *list(zip(image_list, geometry)))
+    return arrange_images(
+        size_xy[0], size_xy[1], *list(zip(image_list, geometry, strict=False))
+    )
 
 
 def measure_text_height_width(text, font_face=None, font_scale=None, thickness=None):
@@ -229,7 +233,7 @@ def render_text_as_image(
 
 def calc_centering_offset(centre_xy, dst_size_xy):
     dst_centre = [i // 2 for i in dst_size_xy]
-    return [i[1] - i[0] for i in zip(centre_xy, dst_centre)]
+    return [i[1] - i[0] for i in zip(centre_xy, dst_centre, strict=False)]
 
 
 def centered_at(image, src_pos, dst_rect):

--- a/mel/rotomap/automark.py
+++ b/mel/rotomap/automark.py
@@ -1,7 +1,6 @@
 """Automatically mark moles on rotomap images."""
 
 import copy
-from typing import Dict, List, Union
 
 import numpy
 
@@ -18,7 +17,7 @@ import mel.rotomap.moles
 # Note that in Python 3.11 we can use TypedDict to enforce this,
 # and make radius NotRequired.
 #
-Moles = List[Dict[str, Union[str, int]]]
+Moles = list[dict[str, str | int]]
 
 
 def merge_in_radiuses(

--- a/mel/rotomap/automarknn.py
+++ b/mel/rotomap/automarknn.py
@@ -121,7 +121,7 @@ class PlModule(pl.LightningModule):
         result = self.model(x, y)
         precision_list = []
         recall_list = []
-        for y_item, result_item in zip(y, result):
+        for y_item, result_item in zip(y, result, strict=False):
             (
                 item_precision,
                 item_recall,
@@ -230,4 +230,4 @@ def drop_paths_without_moles(path_list):
 
 # See https://github.com/pytorch/vision/blob/59ec1dfd550652a493cb99d5704dcddae832a204/references/detection/utils.py#L203
 def collate_fn(batch):
-    return tuple(zip(*batch))
+    return tuple(zip(*batch, strict=False))

--- a/mel/rotomap/filtermarks.py
+++ b/mel/rotomap/filtermarks.py
@@ -249,7 +249,9 @@ def prepare_data(pretrained_data, sessions):
             "is_mole": int(is_mole),
         }
         for image_data in image_dicts
-        for features, is_mole in zip(image_data["features"], image_data["is_mole"])
+        for features, is_mole in zip(
+            image_data["features"], image_data["is_mole"], strict=False
+        )
     ]
 
 

--- a/mel/rotomap/identifynn.py
+++ b/mel/rotomap/identifynn.py
@@ -274,7 +274,7 @@ def frame_to_part_name(frame):
 def unzip_dataset_part(uuid_list, dataset_generator):
     dataset_part = list(dataset_generator)
     data_list = []
-    for uuid_, item in zip(uuid_list, dataset_part):
+    for uuid_, item in zip(uuid_list, dataset_part, strict=False):
         item_uuid, data = item
         if item_uuid != uuid_:
             raise ValueError("uuids don't match")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dependencies = [
     "colorama",
     "opencv-python",
@@ -56,7 +56,7 @@ zip-safe = false
 version = {attr = "mel.__version__"}
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py312"
 
 [tool.ruff.lint]
 # Rule codes enabled for static analysis:
@@ -86,7 +86,7 @@ exclude = ["*__t.py", "mel/rotomap/detectmoles.py", "mel/rotomap/identifynn.py"]
 
 [tool.pyright]
 # Minimal strictness configuration
-pythonVersion = "3.8"
+pythonVersion = "3.12"
 typeCheckingMode = "basic"
 useLibraryCodeForTypes = true
 reportMissingTypeStubs = "none"


### PR DESCRIPTION
Upgrades the minimum Python version requirement from 3.8 to 3.12 to resolve EOL compatibility issues.

## Changes
- Update requires-python to >=3.12 in pyproject.toml
- Update ruff target-version to py312
- Update pyright pythonVersion to 3.12
- Apply ruff autofix for Python 3.12 compatibility issues

## Testing
- All 61 tests pass including doctests
- Static analysis passes after resolving 16 compatibility issues
- Unit tests all pass

Closes #481

Generated with [Claude Code](https://claude.ai/code)