### PR TITLE
Modernize Python syntax from 3.8 to 3.12

### DIFF
--- a/mel/cmd/rotomapautomark2train.py
+++ b/mel/cmd/rotomapautomark2train.py
@@ -145,7 +145,7 @@ def process_args(args):
         num_workers=args.num_workers,
     )
 
-    trainer_kwargs = {
+    base_trainer_kwargs = {
         "log_every_n_steps": 5,
         "enable_checkpointing": False,
         "accelerator": "auto",
@@ -158,11 +158,16 @@ def process_args(args):
         # "auto_lr_find": True,
     }
 
+    wandb_kwargs = {}
     if args.wandb:
         wandb_project, wandb_run_name = args.wandb
-        trainer_kwargs["logger"] = pl.loggers.WandbLogger(
-            project=wandb_project, name=wandb_run_name
-        )
+        wandb_kwargs = {
+            "logger": pl.loggers.WandbLogger(
+                project=wandb_project, name=wandb_run_name
+            )
+        }
+
+    trainer_kwargs = base_trainer_kwargs | wandb_kwargs
 
     if not args.just_validate:
         trainer = pl.Trainer(**trainer_kwargs)

--- a/mel/cmd/rotomapidentifytrain.py
+++ b/mel/cmd/rotomapidentifytrain.py
@@ -179,17 +179,22 @@ def process_args(args):
         "extra_stem": args.extra_stem,
     }
 
-    trainer_kwargs = {
+    base_trainer_kwargs = {
         "max_epochs": args.epochs,
         "accelerator": "auto",
         "log_every_n_steps": 5,
     }
 
+    wandb_kwargs = {}
     if args.wandb:
         wandb_project, wandb_run_name = args.wandb
-        trainer_kwargs["logger"] = pl.loggers.WandbLogger(
-            project=wandb_project, name=wandb_run_name
-        )
+        wandb_kwargs = {
+            "logger": pl.loggers.WandbLogger(
+                project=wandb_project, name=wandb_run_name
+            )
+        }
+
+    trainer_kwargs = base_trainer_kwargs | wandb_kwargs
 
     print("Making data ..")
     (

--- a/mel/cmd/status.py
+++ b/mel/cmd/status.py
@@ -325,15 +325,15 @@ def process_args(args):
         if abspath is not None and not str(notice.path).startswith(abspath):
             continue
 
-        klass = notice.__class__
-        if issubclass(klass, AlertNotification):
-            alerts_to_notices[klass].append(notice)
-        elif issubclass(klass, ErrorNotification):
-            errors_to_notices[klass].append(notice)
-        elif issubclass(klass, InfoNotification):
-            info_to_notices[klass].append(notice)
-        else:
-            raise RuntimeError(f"Unexpected notice type: {klass}")
+        match notice:
+            case AlertNotification():
+                alerts_to_notices[notice.__class__].append(notice)
+            case ErrorNotification():
+                errors_to_notices[notice.__class__].append(notice)
+            case InfoNotification():
+                info_to_notices[notice.__class__].append(notice)
+            case _:
+                raise RuntimeError(f"Unexpected notice type: {notice.__class__}")
 
     any_notices = bool(alerts_to_notices or errors_to_notices)
 

--- a/mel/lib/dinov2.py
+++ b/mel/lib/dinov2.py
@@ -18,19 +18,19 @@ def load_dinov2_model(dino_size="base"):
     import torch
 
     # Map size names to actual model names and their feature dimensions
-    model_configs = {
-        "small": ("dinov2_vits14", 384),
-        "base": ("dinov2_vitb14", 768),
-        "large": ("dinov2_vitl14", 1024),
-        "giant": ("dinov2_vitg14", 1536),
-    }
-
-    if dino_size not in model_configs:
-        raise ValueError(
-            f"Invalid dino_size: {dino_size}. Must be one of {list(model_configs.keys())}"
-        )
-
-    model_name, feature_dim = model_configs[dino_size]
+    match dino_size:
+        case "small":
+            model_name, feature_dim = "dinov2_vits14", 384
+        case "base":
+            model_name, feature_dim = "dinov2_vitb14", 768
+        case "large":
+            model_name, feature_dim = "dinov2_vitl14", 1024
+        case "giant":
+            model_name, feature_dim = "dinov2_vitg14", 1536
+        case _:
+            raise ValueError(
+                f"Invalid dino_size: {dino_size}. Must be one of ['small', 'base', 'large', 'giant']"
+            )
 
     try:
         # Load DINOv2 model for semantic patch features with rich context


### PR DESCRIPTION
This PR modernizes the codebase to take advantage of Python 3.12 syntax improvements, specifically Python 3.9+ dictionary merge operators and Python 3.10+ match statements.

## Changes

**Dictionary Merging with `|` operator (Python 3.9+):**
- `mel/cmd/rotomapautomark2train.py` - Trainer kwargs building
- `mel/cmd/rotomapidentifytrain.py` - Trainer kwargs building

**Match Statements (Python 3.10+):**
- `mel/lib/dinov2.py` - Model configuration dispatch
- `mel/cmd/status.py` - Notification type handling

The changes are purely syntactic and maintain identical behavior while improving code readability and taking advantage of modern Python language features.

Fixes #483

Generated with [Claude Code](https://claude.ai/code)