### PR TITLE
Add rotomap composite command to fill mask-hidden areas

### DIFF
--- a/mel/cmd/mel.py
+++ b/mel/cmd/mel.py
@@ -20,6 +20,7 @@ import mel.cmd.rotomapautomask
 import mel.cmd.rotomapcalcspace
 import mel.cmd.rotomapcompare
 import mel.cmd.rotomapcompareextrastem
+import mel.cmd.rotomapcomposite
 import mel.cmd.rotomapconfirm
 import mel.cmd.rotomapedit
 import mel.cmd.rotomapfiltermarks
@@ -66,6 +67,7 @@ COMMANDS = {
         "calc-space": mel.cmd.rotomapcalcspace,
         "compare": mel.cmd.rotomapcompare,
         "compare-extra-stem": mel.cmd.rotomapcompareextrastem,
+        "composite": mel.cmd.rotomapcomposite,
         "confirm": mel.cmd.rotomapconfirm,
         "edit": mel.cmd.rotomapedit,
         "filter-marks": mel.cmd.rotomapfiltermarks,

--- a/mel/cmd/rotomapcomposite.py
+++ b/mel/cmd/rotomapcomposite.py
@@ -1,0 +1,87 @@
+"""Composite rotomap images by filling mask-hidden areas with a solid color."""
+
+import argparse
+import pathlib
+
+import numpy as np
+
+import mel.cmd.error
+import mel.lib.image
+import mel.rotomap.mask
+
+
+def setup_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "IMAGE",
+        nargs="+",
+        help="JPEG image files to composite with their masks.",
+    )
+    parser.add_argument(
+        "--fill-color",
+        type=str,
+        default="0,0,0",
+        help="BGR fill color for masked-out areas, as B,G,R (default: 0,0,0).",
+    )
+
+
+def _parse_fill_color(fill_color_str: str) -> tuple[int, int, int]:
+    """Parse a comma-separated BGR color string into a tuple of three ints."""
+    parts = fill_color_str.split(",")
+    if len(parts) != 3:
+        msg = f"Fill color must have 3 comma-separated values, got: {fill_color_str}"
+        raise ValueError(msg)
+    values = tuple(int(p.strip()) for p in parts)
+    for v in values:
+        if not 0 <= v <= 255:
+            msg = f"Fill color values must be 0-255, got: {v}"
+            raise ValueError(msg)
+    return values[0], values[1], values[2]
+
+
+def process_args(args: argparse.Namespace) -> None:
+    try:
+        fill_color = _parse_fill_color(args.fill_color)
+    except ValueError as err:
+        msg = str(err)
+        raise mel.cmd.error.UsageError(msg) from err
+
+    for image_path in args.IMAGE:
+        if not image_path.endswith(".jpg"):
+            msg = f"Not a JPEG file: {image_path}"
+            raise mel.cmd.error.UsageError(msg)
+
+        if not pathlib.Path(image_path).exists():
+            msg = f"File not found: {image_path}"
+            raise mel.cmd.error.UsageError(msg)
+
+        mask = mel.rotomap.mask.load_or_none(image_path)
+        if mask is None:
+            print(f"No mask found, skipping: {image_path}")
+            continue
+
+        image = mel.lib.image.load_image(image_path)
+
+        keep_mask = mask > 127
+        for c in range(3):
+            image[:, :, c] = np.where(keep_mask, image[:, :, c], fill_color[c])
+
+        mel.lib.image.save_image(image, image_path)
+        print(f"Composited: {image_path}")
+
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2026 Angelos Evripiotis.
+# Generated with assistance from Claude Code.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------ END-OF-FILE ----------------------------------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -146,6 +146,8 @@ def test_smoke() -> None:
             str(target_image_files[0])
         )
 
+        expect_ok("mel", "rotomap", "composite", str(target_image_files[0]))
+
         expect_ok("mel", "status", "-ttdd")
 
         # Create empty timelog for timelog command test


### PR DESCRIPTION
## Summary
This PR adds a new `rotomap composite` command that processes rotomap images by filling mask-hidden areas with a solid color. This is useful for preparing images where masked-out regions need to be replaced with a uniform background.

## Key Changes
- **New command module**: Added `mel/cmd/rotomapcomposite.py` with functionality to:
  - Load JPEG images and their associated masks
  - Replace masked-out areas (mask values ≤ 127) with a configurable fill color
  - Save the composited images back to disk
  - Support customizable BGR fill color via `--fill-color` argument (default: black `0,0,0`)
  
- **Command registration**: Integrated the new command into the main CLI by:
  - Importing the new module in `mel/cmd/mel.py`
  - Registering it as the `composite` subcommand under `rotomap`

- **Input validation**: Implemented robust error handling for:
  - Fill color parsing (must be 3 comma-separated integers in range 0-255)
  - File existence checks
  - JPEG file format validation

- **Test coverage**: Added smoke test to verify the command executes successfully

## Implementation Details
- Uses NumPy's `where()` function to efficiently apply the mask to each color channel
- Skips images without associated masks with a warning message
- Provides clear user feedback for each processed image

https://claude.ai/code/session_01MTLQqiWZRPjcWZvJz3nt1z